### PR TITLE
Опечатка в поясненнии сравнения с образцом

### DIFF
--- a/chapters/08-choose-n-patterns.md
+++ b/chapters/08-choose-n-patterns.md
@@ -156,7 +156,7 @@ analyzeGold _   = "I don't know such a standard..."
                    к этому      она
                    аргументу    равна
 
-      analyzeGold  750          =      "Wow! 999 standard!"
+      analyzeGold  750          =      "Great! 750 standard."
 
 если  эта функция  применяется  тогда  другому выражению
                    к другому    она


### PR DESCRIPTION
В главе 8-й опечатка в этом фрагменте:
```
      analyzeGold  999          =      "Wow! 999 standard!"

если  эта функция  применяется  тогда  этому выражению
                   к этому      она
                   аргументу    равна

      analyzeGold  750          =      "Wow! 999 standard!"
```